### PR TITLE
fix: Update package.json to match pnpm-lock.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "codemirror": "latest",
     "framer-motion": "latest",
     "lucide-react": "^0.454.0",
-    "mermaid": "^11.9.0",
+    "mermaid": "latest",
     "next": "14.2.16",
     "next-themes": "latest",
     "postcss": "^8.4.0",


### PR DESCRIPTION
- Updated the version of the `mermaid` dependency in `package.json` to match the version in `pnpm-lock.yaml` to resolve the `ERR_PNPM_OUTDATED_LOCKFILE` error.