### PR TITLE
feat: Add mock authentication API endpoints

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  const { email, password } = await request.json();
+
+  if (!email || !password) {
+    return NextResponse.json({ message: 'Missing email or password' }, { status: 400 });
+  }
+
+  // In a real application, you would verify the user's credentials.
+  // Here, we'll just simulate a successful login.
+
+  const user = {
+    id: '1',
+    name: 'Test User',
+    email,
+    role: 'user',
+    subscriptionPlan: 'free',
+    subscriptionStatus: 'active',
+    credits: 10,
+    createdAt: new Date().toISOString(),
+  };
+
+  const token = 'mock-jwt-token';
+  const expiresIn = 3600; // 1 hour
+
+  return NextResponse.json({ user, token, expiresIn });
+}

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  const { email } = await request.json();
+
+  if (!email) {
+    return NextResponse.json({ message: 'Missing email' }, { status: 400 });
+  }
+
+  // In a real application, you would send a password reset email.
+  // Here, we'll just simulate a successful request.
+
+  return NextResponse.json({ message: 'Password reset email sent' });
+}

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  const { name, email, password } = await request.json();
+
+  if (!name || !email || !password) {
+    return NextResponse.json({ message: 'Missing name, email, or password' }, { status: 400 });
+  }
+
+  // In a real application, you would save the user to a database.
+  // Here, we'll just simulate a successful signup.
+
+  const user = {
+    id: '1',
+    name,
+    email,
+    role: 'user',
+    subscriptionPlan: 'free',
+    subscriptionStatus: 'active',
+    credits: 10,
+    createdAt: new Date().toISOString(),
+  };
+
+  const token = 'mock-jwt-token';
+  const expiresIn = 3600; // 1 hour
+
+  return NextResponse.json({ user, token, expiresIn });
+}

--- a/app/api/auth/verify/route.ts
+++ b/app/api/auth/verify/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  const { headers } = request;
+  const authHeader = headers.get('Authorization');
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return NextResponse.json({ message: 'Missing or invalid token' }, { status: 401 });
+  }
+
+  // In a real application, you would verify the token.
+  // Here, we'll just simulate a successful verification.
+
+  const user = {
+    id: '1',
+    name: 'Test User',
+    email: 'test@example.com',
+    role: 'user',
+    subscriptionPlan: 'free',
+    subscriptionStatus: 'active',
+    credits: 10,
+    createdAt: new Date().toISOString(),
+  };
+
+  return NextResponse.json({ user });
+}

--- a/app/api/user/avatar/route.ts
+++ b/app/api/user/avatar/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+
+export async function PUT(request: Request) {
+  const { avatar } = await request.json();
+
+  // In a real application, you would update the user's avatar in the database.
+  // Here, we'll just simulate a successful update.
+
+  const updatedUser = {
+    id: '1',
+    name: 'Test User',
+    email: 'test@example.com',
+    avatar,
+    role: 'user',
+    subscriptionPlan: 'free',
+    subscriptionStatus: 'active',
+    credits: 10,
+    createdAt: new Date().toISOString(),
+  };
+
+  return NextResponse.json(updatedUser);
+}

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+
+export async function PUT(request: Request) {
+  const { name, email, bio } = await request.json();
+
+  // In a real application, you would update the user's profile in the database.
+  // Here, we'll just simulate a successful update.
+
+  const updatedUser = {
+    id: '1',
+    name,
+    email,
+    bio,
+    role: 'user',
+    subscriptionPlan: 'free',
+    subscriptionStatus: 'active',
+    credits: 10,
+    createdAt: new Date().toISOString(),
+  };
+
+  return NextResponse.json(updatedUser);
+}

--- a/app/api/user/subscription/route.ts
+++ b/app/api/user/subscription/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+export async function PUT(request: Request) {
+  const { plan } = await request.json();
+
+  // In a real application, you would update the user's subscription in the database.
+  // Here, we'll just simulate a successful update.
+
+  const updatedUser = {
+    id: '1',
+    name: 'Test User',
+    email: 'test@example.com',
+    role: 'user',
+    subscriptionPlan: plan,
+    subscriptionStatus: 'active',
+    credits: 10,
+    createdAt: new Date().toISOString(),
+  };
+
+  return NextResponse.json(updatedUser);
+}


### PR DESCRIPTION
Creates a set of mock API endpoints to simulate a full authentication system. This allows the frontend to function as expected for development and testing purposes without requiring a live backend.

The following endpoints have been created:
- `POST /api/auth/signup`: Simulates user registration.
- `POST /api/auth/login`: Simulates user login.
- `GET /api/auth/verify`: Simulates token verification.
- `POST /api/auth/reset-password`: Simulates sending a password reset email.
- `PUT /api/user/profile`: Simulates updating a user's profile.
- `PUT /api/user/avatar`: Simulates updating a user's avatar.
- `PUT /api/user/subscription`: Simulates updating a user's subscription.