### PR TITLE
feat: update billing and dashboard pages

### DIFF
--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -1,438 +1,614 @@
-"use client"
+."use client"
 
-import type React from "react"
-
-import { useState, useRef } from "react"
+import { useState } from "react"
+import { useAuth } from "@/contexts/auth-context"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Separator } from "@/components/ui/separator"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Badge } from "@/components/ui/badge"
-import { CreditCard, Lock, CheckCircle, AlertCircle, HelpCircle } from "lucide-react"
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { Check, CreditCard, Calendar, Download, Crown, ArrowLeft, Loader2, CheckCircle } from "lucide-react"
+import { useToast } from "@/components/ui/use-toast"
+import AppLayout from "@/components/app-layout"
+import { useRequireAuth } from "@/hooks/use-require-auth"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { Label } from "@/components/ui/label"
+import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { useRouter } from "next/navigation"
 
-interface CardPaymentFormProps {
-onBack: () => void
-onSuccess: () => void
-}
+export default function BillingPage() {
+  const { user, updateSubscription } = useAuth()
+  const { requireAuth } = useRequireAuth()
+  const router = useRouter()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [activeTab, setActiveTab] = useState("plans")
+  const [selectedPlan, setSelectedPlan] = useState<"free" | "premium">(user?.subscriptionPlan || "free")
+  const [paymentMethod, setPaymentMethod] = useState<"card" | "paypal">("card")
+  const [confirmDialogOpen, setConfirmDialogOpen] = useState(false)
+  const [paymentProcessing, setPaymentProcessing] = useState(false)
+  const [paymentSuccess, setPaymentSuccess] = useState(false)
+  const { toast } = useToast()
 
-interface CardState {
-number: string
-expiry: string
-cvc: string
-country: string
-}
+  // Credit card form state
+  const [cardDetails, setCardDetails] = useState({
+    number: "",
+    expiry: "",
+    cvc: "",
+    name: "",
+    email: user?.email || "",
+    address: "",
+    city: "",
+    country: "",
+    postalCode: "",
+  })
 
-interface ValidationState {
-number: "incomplete" | "complete" | "invalid"
-expiry: "incomplete" | "complete" | "invalid"
-cvc: "incomplete" | "complete" | "invalid"
-}
+  if (!user) return null
 
-export default function CardPaymentForm({ onBack, onSuccess }: CardPaymentFormProps) {
-const [cardData, setCardData] = useState<CardState>({
-number: "",
-expiry: "",
-cvc: "",
-country: "Kenya",
-})
+  // Calculate days left in trial if applicable
+  const daysLeftInTrial = user.trialEndsAt
+    ? Math.max(0, Math.ceil((new Date(user.trialEndsAt).getTime() - Date.now()) / (1000 * 60 * 60 * 24)))
+    : 0
 
-const [validation, setValidation] = useState<ValidationState>({
-number: "incomplete",
-expiry: "incomplete",
-cvc: "incomplete",
-})
+  const totalTrialDays = 14
+  const daysUsed = totalTrialDays - daysLeftInTrial
+  const trialProgress = (daysUsed / totalTrialDays) * 100
 
-const [isProcessing, setIsProcessing] = useState(false)
+  const premiumBenefits = [
+    { icon: "⚡", text: "Unlimited generations" },
+    { icon: "💻", text: "Unlimited code generation" },
+    { icon: "📊", text: "Mermaid architecture diagrams" },
+    { icon: "🔍", text: "Explanations for debugging & code optimization" },
+    { icon: "🧪", text: "Automated testing" },
+    { icon: "🔗", text: "Full API integrations (GitHub, Swagger, Firebase)" },
+    { icon: "🎯", text: "Priority support" },
+    { icon: "🚀", text: "Early access to new features" },
+    { icon: "📈", text: "Advanced analytics" },
+  ]
 
-const expiryRef = useRef<HTMLInputElement>(null)
-const cvcRef = useRef<HTMLInputElement>(null)
+  const handlePayment = async () => {
+    if (!requireAuth("processing payment")) {
+      return
+    }
 
-const countries = [
-"Kenya",
-"South Africa",
-"Nigeria",
-"Ghana",
-"Uganda",
-"Tanzania",
-"United States",
-"United Kingdom",
-"Canada",
-"Australia",
-"Germany",
-"France",
-]
+    setPaymentProcessing(true)
 
-const formatCardNumber = (value: string) => {
-const v = value.replace(/\s+/g, "").replace(/[^0-9]/gi, "")
-const matches = v.match(/\d{4,16}/g)
-const match = (matches && matches[0]) || ""
-const parts = []
-for (let i = 0, len = match.length; i < len; i += 4) {
-parts.push(match.substring(i, i + 4))
-}
-if (parts.length) {
-return parts.join(" ")
-} else {
-return v
-}
-}
+    try {
+      // Simulate payment processing
+      await new Promise((resolve) => setTimeout(resolve, 3000))
 
-const formatExpiry = (value: string) => {
-const v = value.replace(/\D/g, "")
-if (v.length >= 2) {
-return v.substring(0, 2) + "/" + v.substring(2, 4)
-}
-return v
-}
+      // Simulate successful payment
+      await updateSubscription("premium")
 
-const validateCardNumber = (number: string): "incomplete" | "complete" | "invalid" => {
-const cleaned = number.replace(/\s/g, "")
-if (cleaned.length === 0) return "incomplete"
-if (cleaned.length < 16) return "incomplete"
-if (cleaned.length === 16 && /^\d+$/.test(cleaned)) return "complete"
-return "invalid"
-}
+      setPaymentSuccess(true)
+      setConfirmDialogOpen(false)
 
-const validateExpiry = (expiry: string): "incomplete" | "complete" | "invalid" => {
-if (expiry.length === 0) return "incomplete"
-if (expiry.length < 5) return "incomplete"
+      toast({
+        title: "Payment Successful!",
+        description: "Welcome to CodeFusion Premium! You now have unlimited access to all features.",
+      })
 
-const [month, year] = expiry.split("/")
-const monthNum = Number.parseInt(month)
-const yearNum = Number.parseInt("20" + year)
-const currentYear = new Date().getFullYear()
-const currentMonth = new Date().getMonth() + 1
-
-if (monthNum < 1 || monthNum > 12) return "invalid"
-if (yearNum < currentYear || (yearNum === currentYear && monthNum < currentMonth)) return "invalid"
-
-return "complete"
-
-}
-
-const validateCVC = (cvc: string): "incomplete" | "complete" | "invalid" => {
-if (cvc.length === 0) return "incomplete"
-if (cvc.length < 3) return "incomplete"
-if (cvc.length === 3 && /^\d+$/.test(cvc)) return "complete"
-return "invalid"
-}
-
-const handleCardNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-const formatted = formatCardNumber(e.target.value)
-if (formatted.length <= 19) {
-setCardData((prev) => ({ ...prev, number: formatted }))
-setValidation((prev) => ({ ...prev, number: validateCardNumber(formatted) }))
-
-if (formatted.replace(/\s/g, "").length === 16) {
-    expiryRef.current?.focus()
+      // Redirect to dashboard after success
+      setTimeout(() => {
+        router.push("/dashboard")
+      }, 2000)
+    } catch (error) {
+      toast({
+        title: "Payment Failed",
+        description: "There was a problem processing your payment. Please try again.",
+        variant: "destructive",
+      })
+    } finally {
+      setPaymentProcessing(false)
+    }
   }
-}
 
-}
-
-const handleExpiryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-const formatted = formatExpiry(e.target.value)
-if (formatted.length <= 5) {
-setCardData((prev) => ({ ...prev, expiry: formatted }))
-setValidation((prev) => ({ ...prev, expiry: validateExpiry(formatted) }))
-
-if (formatted.length === 5) {
-    cvcRef.current?.focus()
+  const handleTabChange = (value: string) => {
+    if (requireAuth(`viewing ${value} information`)) {
+      setActiveTab(value)
+    }
   }
-}
 
-}
+  const handlePlanSelect = (plan: "free" | "premium") => {
+    if (requireAuth(`selecting the ${plan} plan`)) {
+      setSelectedPlan(plan)
+      if (user.subscriptionPlan !== plan && plan === "premium") {
+        setConfirmDialogOpen(true)
+      }
+    }
+  }
 
-const handleCVCChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-const value = e.target.value.replace(/\D/g, "")
-if (value.length <= 3) {
-setCardData((prev) => ({ ...prev, cvc: value }))
-setValidation((prev) => ({ ...prev, cvc: validateCVC(value) }))
-}
-}
+  const handleDownloadInvoice = () => {
+    requireAuth("downloading invoices")
+  }
 
-const getCardType = (number: string) => {
-const cleaned = number.replace(/\s/g, "")
-if (cleaned.startsWith("4")) return "visa"
-if (cleaned.startsWith("5") || cleaned.startsWith("2")) return "mastercard"
-return "unknown"
-}
+  const formatCardNumber = (value: string) => {
+    const v = value.replace(/\s+/g, "").replace(/[^0-9]/gi, "")
+    const matches = v.match(/\d{4,16}/g)
+    const match = (matches && matches[0]) || ""
+    const parts = []
+    for (let i = 0, len = match.length; i < len; i += 4) {
+      parts.push(match.substring(i, i + 4))
+    }
+    if (parts.length) {
+      return parts.join(" ")
+    } else {
+      return v
+    }
+  }
 
-const isFormValid = () => {
-return (
-validation.number === "complete" &&
-validation.expiry === "complete" &&
-validation.cvc === "complete" &&
-cardData.country
-)
-}
+  const formatExpiry = (value: string) => {
+    const v = value.replace(/\s+/g, "").replace(/[^0-9]/gi, "")
+    if (v.length >= 2) {
+      return v.substring(0, 2) + "/" + v.substring(2, 4)
+    }
+    return v
+  }
 
-const handleSubmit = async () => {
-if (!isFormValid()) return
+  return (
+    <AppLayout>
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="icon" onClick={() => router.back()}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Billing & Subscription</h1>
+            <p className="text-muted-foreground">Manage your subscription and billing information</p>
+          </div>
+        </div>
 
-setIsProcessing(true)
-await new Promise((resolve) => setTimeout(resolve, 3000))
-setIsProcessing(false)
-onSuccess()
+        <Tabs defaultValue="plans" value={activeTab} onValueChange={handleTabChange}>
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="plans">Subscription Plans</TabsTrigger>
+            <TabsTrigger value="history">Billing History</TabsTrigger>
+          </TabsList>
 
-}
+          <TabsContent value="plans" className="space-y-6">
+            {/* Current Plan Status */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  Current Plan
+                  {user.subscriptionPlan === "premium" && (
+                    <Badge className="bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300">
+                      <Crown className="h-3 w-3 mr-1" />
+                      Premium
+                    </Badge>
+                  )}
+                </CardTitle>
+                <CardDescription>
+                  You are currently on the {user.subscriptionPlan === "premium" ? "Premium" : "Free"} plan.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="rounded-md border p-4">
+                  <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <h3 className="text-lg font-medium">
+                          {user.subscriptionPlan === "premium" ? "Premium Plan" : "Free Plan"}
+                        </h3>
+                        <Badge variant={user.subscriptionPlan === "premium" ? "default" : "outline"}>
+                          {user.subscriptionStatus === "trial" ? "Trial" : "Active"}
+                        </Badge>
+                      </div>
+                      <p className="text-sm text-muted-foreground mt-1">
+                        {user.subscriptionPlan === "premium"
+                          ? "✅ Premium active – enjoy unlimited benefits!"
+                          : user.subscriptionStatus === "trial"
+                            ? `14-day free trial with unlimited features. ${daysLeftInTrial} days remaining.`
+                            : "Limited access to basic features"}
+                      </p>
+                    </div>
 
-const getValidationIcon = (state: "incomplete" | "complete" | "invalid") => {
-if (state === "complete") return <CheckCircle className="h-4 w-4 text-green-500" />
-if (state === "invalid") return <AlertCircle className="h-4 w-4 text-red-500" />
-return null
-}
-
-const getValidationMessage = (field: keyof ValidationState) => {
-const state = validation[field]
-const fieldNames = {
-number: "Card number",
-expiry: "Expiry date",
-cvc: "Security code",
-}
-
-if (state === "complete") return `${fieldNames[field]} is complete`
-if (state === "invalid") return `${fieldNames[field]} is invalid`
-return `${fieldNames[field]} is incomplete`
-
-}
-
-return (
-<div className="w-full max-w-4xl mx-auto space-y-6 p-4">
-{/* Plan Summary */}
-<Card className="border-indigo-200 bg-gradient-to-r from-indigo-50 to-blue-50">
-<CardHeader>
-<div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
-<div>
-<CardTitle className="text-xl lg:text-2xl">Social Pro Premium</CardTitle>
-<CardDescription className="text-base">Complete your upgrade</CardDescription>
-</div>
-<div className="text-left lg:text-right">
-<div className="text-2xl lg:text-3xl font-bold">$30/month</div>
-<Badge variant="secondary">Premium Plan</Badge>
-</div>
-</div>
-</CardHeader>
-<CardContent>
-<div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-<div className="flex items-center space-x-2">
-<CheckCircle className="h-4 w-4 text-green-500 flex-shrink-0" />
-<span className="text-sm">$30 of usage credit per month</span>
-</div>
-<div className="flex items-center space-x-2">
-<CheckCircle className="h-4 w-4 text-green-500 flex-shrink-0" />
-<span className="text-sm">Purchase additional credits outside your monthly limits</span>
-</div>
-<div className="flex items-center space-x-2">
-<CheckCircle className="h-4 w-4 text-green-500 flex-shrink-0" />
-<span className="text-sm">Unlimited Scheduled Posting</span>
-</div>
-<div className="flex items-center space-x-2">
-<CheckCircle className="h-4 w-4 text-green-500 flex-shrink-0" />
-<span className="text-sm">Unlimited posting to all social media accounts</span>
-</div>
-<div className="flex items-center space-x-2">
-<CheckCircle className="h-4 w-4 text-green-500 flex-shrink-0" />
-<span className="text-sm">SEO Optimization Tools</span>
-</div>
-<div className="flex items-center space-x-2">
-<CheckCircle className="h-4 w-4 text-green-500 flex-shrink-0" />
-<span className="text-sm">Collaborative Roles</span>
-</div>
-</div>
-</CardContent>
-</Card>
-
-{/* Payment Form */}
-  <Card>
-    <CardHeader>
-      <CardTitle className="flex items-center space-x-2">
-        <CreditCard className="h-5 w-5" />
-        <span>Payment Information</span>
-      </CardTitle>
-      <CardDescription>Enter your card details to complete your subscription</CardDescription>
-    </CardHeader>
-    <CardContent className="space-y-6">
-      {/* Card Number */}
-      <div className="space-y-2">
-        <Label htmlFor="card-number">Card Number</Label>
-        <div className="relative">
-          <Input
-            id="card-number"
-            placeholder="1234 1234 1234 1234"
-            value={cardData.number}
-            onChange={handleCardNumberChange}
-            className={`pr-20 ${
-              validation.number === "invalid"
-                ? "border-red-500"
-                : validation.number === "complete"
-                  ? "border-green-500"
-                  : ""
-            }`}
-          />
-          <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center space-x-2">
-            {getValidationIcon(validation.number)}
-            <div className="flex space-x-1">
-              {getCardType(cardData.number) === "visa" && (
-                <div className="w-8 h-5 bg-blue-600 text-white text-xs flex items-center justify-center rounded font-bold">
-                  VISA
+                    {user.subscriptionPlan === "premium" ? (
+                      <Button variant="outline" disabled>
+                        <CheckCircle className="mr-2 h-4 w-4 text-green-600" />
+                        Premium Active
+                      </Button>
+                    ) : (
+                      <Button
+                        className="bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700"
+                        onClick={() => handlePlanSelect("premium")}
+                      >
+                        <Crown className="mr-2 h-4 w-4" />
+                        Upgrade to Premium
+                      </Button>
+                    )}
+                  </div>
                 </div>
-              )}
-              {getCardType(cardData.number) === "mastercard" && (
-                <div className="w-8 h-5 bg-red-600 text-white text-xs flex items-center justify-center rounded font-bold">
-                  MC
-                </div>
-              )}
+              </CardContent>
+            </Card>
+
+            {/* Plan Comparison */}
+            <div className="grid gap-6 md:grid-cols-2">
+              <Card className={selectedPlan === "free" ? "border-primary" : ""}>
+                <CardHeader>
+                  <CardTitle className="flex items-center justify-between">
+                    Free Plan
+                    {user.subscriptionPlan === "free" && (
+                      <Badge variant="outline" className="ml-2">
+                        Current Plan
+                      </Badge>
+                    )}
+                  </CardTitle>
+                  <CardDescription>14-day trial with unlimited features</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="text-3xl font-bold">$0</div>
+                  <ul className="space-y-2 text-sm">
+                    <li className="flex items-start gap-2">
+                      <Check className="h-4 w-4 text-primary mt-0.5" />
+                      <span>14-day free trial</span>
+                    </li>
+                    <li className="flex items-start gap-2">
+                      <Check className="h-4 w-4 text-primary mt-0.5" />
+                      <span>Unlimited access during trial</span>
+                    </li>
+                    <li className="flex items-start gap-2">
+                      <Check className="h-4 w-4 text-primary mt-0.5" />
+                      <span>Basic support</span>
+                    </li>
+                    <li className="flex items-start gap-2">
+                      <Check className="h-4 w-4 text-primary mt-0.5" />
+                      <span>Community access</span>
+                    </li>
+                  </ul>
+                </CardContent>
+                <CardFooter>
+                  <Button variant="outline" className="w-full bg-transparent" disabled>
+                    {user.subscriptionPlan === "free" ? "Current Plan" : "Free Plan"}
+                  </Button>
+                </CardFooter>
+              </Card>
+
+              <Card
+                className={`${selectedPlan === "premium" ? "border-primary" : ""} ${user.subscriptionPlan === "premium" ? "bg-gradient-to-br from-purple-50 to-blue-50 dark:from-purple-950 dark:to-blue-950" : ""}`}
+              >
+                <CardHeader>
+                  <CardTitle className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      Premium Plan
+                      <Crown className="h-5 w-5 text-purple-600" />
+                    </div>
+                    {user.subscriptionPlan === "premium" && (
+                      <Badge className="bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300">
+                        Active
+                      </Badge>
+                    )}
+                  </CardTitle>
+                  <CardDescription>Unlimited access to all premium features</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="text-3xl font-bold">
+                    $15<span className="text-sm font-normal text-muted-foreground">/month</span>
+                  </div>
+                  <div className="space-y-2">
+                    {premiumBenefits.map((benefit, i) => (
+                      <div key={i} className="flex items-start gap-2 text-sm">
+                        <span className="text-base">{benefit.icon}</span>
+                        <span>{benefit.text}</span>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+                <CardFooter>
+                  {user.subscriptionPlan === "premium" ? (
+                    <Button variant="outline" className="w-full bg-transparent" disabled>
+                      <CheckCircle className="mr-2 h-4 w-4 text-green-600" />✅ Premium active – enjoy benefits!
+                    </Button>
+                  ) : (
+                    <Button
+                      className="w-full bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700"
+                      onClick={() => handlePlanSelect("premium")}
+                    >
+                      <Crown className="mr-2 h-4 w-4" />
+                      Pay $15/month
+                    </Button>
+                  )}
+                </CardFooter>
+              </Card>
             </div>
-          </div>
-        </div>
-        <p
-          className={`text-xs ${
-            validation.number === "invalid"
-              ? "text-red-500"
-              : validation.number === "complete"
-                ? "text-green-500"
-                : "text-gray-500"
-          }`}
-        >
-          {getValidationMessage("number")}
-        </p>
+          </TabsContent>
+
+          <TabsContent value="history" className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Billing History</CardTitle>
+                <CardDescription>View your billing history and download invoices</CardDescription>
+              </CardHeader>
+              <CardContent>
+                {user.subscriptionPlan === "premium" ? (
+                  <div className="space-y-4">
+                    {[
+                      { date: "2024-01-01", amount: "$15.00", status: "Paid", invoice: "INV-001" },
+                      { date: "2023-12-01", amount: "$15.00", status: "Paid", invoice: "INV-002" },
+                      { date: "2023-11-01", amount: "$15.00", status: "Paid", invoice: "INV-003" },
+                    ].map((invoice, i) => (
+                      <div key={i} className="flex items-center justify-between py-4 border-b last:border-0">
+                        <div className="flex items-center gap-4">
+                          <div className="rounded-full p-2 bg-primary/10">
+                            <Calendar className="h-4 w-4 text-primary" />
+                          </div>
+                          <div>
+                            <p className="font-medium">Premium Plan - {invoice.invoice}</p>
+                            <p className="text-sm text-muted-foreground">{invoice.date}</p>
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-4">
+                          <p className="font-medium">{invoice.amount}</p>
+                          <Badge
+                            variant="outline"
+                            className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300"
+                          >
+                            {invoice.status}
+                          </Badge>
+                          <Button variant="ghost" size="icon" onClick={handleDownloadInvoice}>
+                            <Download className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="flex flex-col items-center justify-center py-8 text-center">
+                    <div className="rounded-full p-3 bg-primary/10 mb-4">
+                      <CreditCard className="h-6 w-6 text-primary" />
+                    </div>
+                    <h3 className="text-lg font-medium">No billing history</h3>
+                    <p className="text-sm text-muted-foreground mt-1 max-w-md">
+                      You are currently on the Free plan. Upgrade to Premium to view your billing history.
+                    </p>
+                    <Button className="mt-4" onClick={() => setActiveTab("plans")}>
+                      View Plans
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+
+        {/* Payment Dialog */}
+        <Dialog open={confirmDialogOpen} onOpenChange={setConfirmDialogOpen}>
+          <DialogContent className="max-w-2xl">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Crown className="h-5 w-5 text-purple-600" />
+                Upgrade to Premium
+              </DialogTitle>
+              <DialogDescription>
+                Complete your payment to unlock unlimited access to all premium features.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-6 py-4">
+              {/* Payment Method Selection */}
+              <div className="space-y-3">
+                <h4 className="text-sm font-medium">Payment Method</h4>
+                <RadioGroup
+                  value={paymentMethod}
+                  onValueChange={(value) => setPaymentMethod(value as "card" | "paypal")}
+                  className="grid grid-cols-2 gap-4"
+                >
+                  <div>
+                    <RadioGroupItem value="card" id="card" className="sr-only peer" />
+                    <Label
+                      htmlFor="card"
+                      className="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground peer-data-[state=checked]:border-primary [&:has([data-state=checked])]:border-primary cursor-pointer"
+                    >
+                      <CreditCard className="h-6 w-6 mb-2" />
+                      Credit Card
+                    </Label>
+                  </div>
+                  <div>
+                    <RadioGroupItem value="paypal" id="paypal" className="sr-only peer" />
+                    <Label
+                      htmlFor="paypal"
+                      className="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground peer-data-[state=checked]:border-primary [&:has([data-state=checked])]:border-primary cursor-pointer"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="h-6 w-6 mb-2">
+                        <path
+                          d="M7.076 21.337H2.47a.641.641 0 0 1-.633-.74L4.944.901C5.026.382 5.474 0 5.998 0h7.46c2.57 0 4.578.543 5.69 1.81 1.01 1.15 1.304 2.42 1.012 4.287-.023.143-.047.288-.077.437-.983 5.05-4.349 6.797-8.647 6.797h-2.19c-.524 0-.968.382-1.05.9l-1.12 7.106zm14.146-14.42a3.35 3.35 0 0 0-.607-.541c-.013.076-.026.175-.041.254-.59 3.025-2.566 4.643-5.813 4.643h-2.189c-.988 0-1.829.722-1.968 1.698l-1.12 7.106c-.022.132-.004.267.05.385h3.578c.524 0 .968-.382 1.05-.9l.466-2.942c.14-.976.981-1.698 1.968-1.698h.627c3.595 0 6.664-1.414 7.612-5.618.386-1.724.162-3.14-.613-4.387z"
+                          fill="#00457c"
+                        />
+                      </svg>
+                      PayPal
+                    </Label>
+                  </div>
+                </RadioGroup>
+              </div>
+
+              {/* Credit Card Form */}
+              {paymentMethod === "card" && (
+                <div className="space-y-4">
+                  <Separator />
+                  <h4 className="text-sm font-medium">Card Information</h4>
+
+                  <div className="grid grid-cols-1 gap-4">
+                    <div>
+                      <Label htmlFor="cardNumber">Card Number</Label>
+                      <Input
+                        id="cardNumber"
+                        placeholder="1234 5678 9012 3456"
+                        value={cardDetails.number}
+                        onChange={(e) => setCardDetails({ ...cardDetails, number: formatCardNumber(e.target.value) })}
+                        maxLength={19}
+                      />
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <Label htmlFor="expiry">Expiry Date</Label>
+                        <Input
+                          id="expiry"
+                          placeholder="MM/YY"
+                          value={cardDetails.expiry}
+                          onChange={(e) => setCardDetails({ ...cardDetails, expiry: formatExpiry(e.target.value) })}
+                          maxLength={5}
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="cvc">CVC</Label>
+                        <Input
+                          id="cvc"
+                          placeholder="123"
+                          value={cardDetails.cvc}
+                          onChange={(e) => setCardDetails({ ...cardDetails, cvc: e.target.value.replace(/\D/g, "") })}
+                          maxLength={4}
+                        />
+                      </div>
+                    </div>
+
+                    <div>
+                      <Label htmlFor="cardName">Cardholder Name</Label>
+                      <Input
+                        id="cardName"
+                        placeholder="John Doe"
+                        value={cardDetails.name}
+                        onChange={(e) => setCardDetails({ ...cardDetails, name: e.target.value })}
+                      />
+                    </div>
+                  </div>
+
+                  <Separator />
+                  <h4 className="text-sm font-medium">Billing Address</h4>
+
+                  <div className="grid grid-cols-1 gap-4">
+                    <div>
+                      <Label htmlFor="email">Email</Label>
+                      <Input
+                        id="email"
+                        type="email"
+                        value={cardDetails.email}
+                        onChange={(e) => setCardDetails({ ...cardDetails, email: e.target.value })}
+                      />
+                    </div>
+
+                    <div>
+                      <Label htmlFor="address">Address</Label>
+                      <Input
+                        id="address"
+                        placeholder="123 Main St"
+                        value={cardDetails.address}
+                        onChange={(e) => setCardDetails({ ...cardDetails, address: e.target.value })}
+                      />
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <Label htmlFor="city">City</Label>
+                        <Input
+                          id="city"
+                          placeholder="New York"
+                          value={cardDetails.city}
+                          onChange={(e) => setCardDetails({ ...cardDetails, city: e.target.value })}
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="postalCode">Postal Code</Label>
+                        <Input
+                          id="postalCode"
+                          placeholder="10001"
+                          value={cardDetails.postalCode}
+                          onChange={(e) => setCardDetails({ ...cardDetails, postalCode: e.target.value })}
+                        />
+                      </div>
+                    </div>
+
+                    <div>
+                      <Label htmlFor="country">Country</Label>
+                      <Input
+                        id="country"
+                        placeholder="United States"
+                        value={cardDetails.country}
+                        onChange={(e) => setCardDetails({ ...cardDetails, country: e.target.value })}
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Order Summary */}
+              <div className="bg-muted/50 rounded-lg p-4 space-y-2">
+                <h4 className="font-medium">Order Summary</h4>
+                <div className="flex justify-between text-sm">
+                  <span>CodeFusion Premium (Monthly)</span>
+                  <span>$15.00</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span>Tax</span>
+                  <span>$0.00</span>
+                </div>
+                <Separator />
+                <div className="flex justify-between font-medium">
+                  <span>Total</span>
+                  <span>$15.00/month</span>
+                </div>
+              </div>
+            </div>
+
+            <DialogFooter className="flex flex-col sm:flex-row gap-2">
+              <Button variant="outline" onClick={() => setConfirmDialogOpen(false)} disabled={paymentProcessing}>
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back
+              </Button>
+              <Button
+                onClick={handlePayment}
+                disabled={paymentProcessing}
+                className="bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700"
+              >
+                {paymentProcessing ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Processing...
+                  </>
+                ) : (
+                  <>
+                    <CreditCard className="mr-2 h-4 w-4" />
+                    Pay $15/month
+                  </>
+                )}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {/* Success Dialog */}
+        <Dialog open={paymentSuccess} onOpenChange={setPaymentSuccess}>
+          <DialogContent className="max-w-md text-center">
+            <DialogHeader>
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+                <CheckCircle className="h-6 w-6 text-green-600" />
+              </div>
+              <DialogTitle>Payment Successful!</DialogTitle>
+              <DialogDescription>
+                Welcome to CodeFusion Premium! You now have unlimited access to all features.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="py-4">
+              <div className="space-y-2 text-sm text-muted-foreground">
+                <p>✅ Unlimited generations activated</p>
+                <p>✅ Premium features unlocked</p>
+                <p>✅ Priority support enabled</p>
+              </div>
+            </div>
+            <DialogFooter>
+              <Button onClick={() => router.push("/dashboard")} className="w-full">
+                Go to Dashboard
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        {/* Expiry Date */}
-        <div className="space-y-2">
-          <Label htmlFor="expiry">Expiry Date</Label>
-          <div className="relative">
-            <Input
-              ref={expiryRef}
-              id="expiry"
-              placeholder="MM/YY"
-              value={cardData.expiry}
-              onChange={handleExpiryChange}
-              className={`${
-                validation.expiry === "invalid"
-                  ? "border-red-500"
-                  : validation.expiry === "complete"
-                    ? "border-green-500"
-                    : ""
-              }`}
-            />
-            <div className="absolute right-3 top-1/2 -translate-y-1/2">{getValidationIcon(validation.expiry)}</div>
-          </div>
-          <p
-            className={`text-xs ${
-              validation.expiry === "invalid"
-                ? "text-red-500"
-                : validation.expiry === "complete"
-                  ? "text-green-500"
-                  : "text-gray-500"
-            }`}
-          >
-            {getValidationMessage("expiry")}
-          </p>
-        </div>
-
-        {/* CVC */}
-        <div className="space-y-2">
-          <div className="flex items-center space-x-1">
-            <Label htmlFor="cvc">Security Code (CVC)</Label>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger>
-                  <HelpCircle className="h-3 w-3 text-gray-400" />
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>3-digit code on back of card</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
-          <div className="relative">
-            <Input
-              ref={cvcRef}
-              id="cvc"
-              placeholder="123"
-              value={cardData.cvc}
-              onChange={handleCVCChange}
-              className={`${
-                validation.cvc === "invalid"
-                  ? "border-red-500"
-                  : validation.cvc === "complete"
-                    ? "border-green-500"
-                    : ""
-              }`}
-            />
-            <div className="absolute right-3 top-1/2 -translate-y-1/2">{getValidationIcon(validation.cvc)}</div>
-          </div>
-          <p
-            className={`text-xs ${
-              validation.cvc === "invalid"
-                ? "text-red-500"
-                : validation.cvc === "complete"
-                  ? "text-green-500"
-                  : "text-gray-500"
-            }`}
-          >
-            {getValidationMessage("cvc")}
-          </p>
-        </div>
-      </div>
-
-      {/* Country */}
-      <div className="space-y-2">
-        <Label>Country</Label>
-        <Select
-          value={cardData.country}
-          onValueChange={(value) => setCardData((prev) => ({ ...prev, country: value }))}
-        >
-          <SelectTrigger>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {countries.map((country) => (
-              <SelectItem key={country} value={country}>
-                {country}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      <Separator />
-
-      {/* Action Buttons */}
-      <div className="space-y-4">
-        <div className="flex flex-col sm:flex-row space-y-3 sm:space-y-0 sm:space-x-3">
-          <Button variant="outline" onClick={onBack} className="flex-1 bg-transparent">
-            Back
-          </Button>
-          <Button onClick={handleSubmit} disabled={!isFormValid() || isProcessing} className="flex-1">
-            {isProcessing ? (
-              <>
-                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                Processing...
-              </>
-            ) : (
-              <>
-                <Lock className="h-4 w-4 mr-2" />
-                Pay $15/month
-              </>
-            )}
-          </Button>
-        </div>
-
-        <div className="text-xs text-gray-500 text-center px-4">
-          By clicking "Pay $15/month", you'll start your Premium plan subscription of $15/month, with a renewal date
-          of the same date each month.
-        </div>
-      </div>
-    </CardContent>
-  </Card>
-</div>
-
-)
+    </AppLayout>
+  )
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,321 @@
+"use client"
+
+import { useAuth } from "@/contexts/auth-context"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Progress } from "@/components/ui/progress"
+import { CreditCard, User, Settings, Crown, Zap, Shield, TrendingUp } from "lucide-react"
+import Link from "next/link"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { Badge } from "@/components/ui/badge"
+
+export default function DashboardPage() {
+  const { user } = useAuth()
+
+  if (!user) return null
+
+  // Calculate days left in trial if applicable
+  const daysLeftInTrial = user.trialEndsAt
+    ? Math.max(0, Math.ceil((new Date(user.trialEndsAt).getTime() - Date.now()) / (1000 * 60 * 60 * 24)))
+    : 0
+
+  // Calculate trial progress (14-day trial)
+  const totalTrialDays = 14
+  const daysUsed = totalTrialDays - daysLeftInTrial
+  const trialProgress = (daysUsed / totalTrialDays) * 100
+
+  // Determine credits remaining
+  const getCreditsDisplay = () => {
+    if (user.subscriptionPlan === "premium") {
+      return "Unlimited Premium Access"
+    }
+
+    if (user.subscriptionStatus === "trial" && daysLeftInTrial > 0) {
+      return `${daysLeftInTrial} Free Trial Days Remaining`
+    }
+
+    return "End of Free Tier – Upgrade to Access Premium Features"
+  }
+
+  const getCreditsColor = () => {
+    if (user.subscriptionPlan === "premium") return "text-green-600"
+    if (user.subscriptionStatus === "trial" && daysLeftInTrial > 0) return "text-blue-600"
+    return "text-red-600"
+  }
+
+  const premiumBenefits = [
+    "✅ Unlimited generations",
+    "✅ Unlimited code generation",
+    "✅ Mermaid architecture diagrams",
+    "✅ Explanations for debugging & code optimization",
+    "✅ Automated testing",
+    "✅ Full API integrations (GitHub, Swagger, Firebase)",
+    "✅ Priority support",
+    "✅ Early access to new features",
+    "✅ Advanced analytics",
+  ]
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
+        <p className="text-muted-foreground">Welcome back, {user.name}!</p>
+      </div>
+
+      {/* Trial Status Card */}
+      {user.subscriptionPlan === "free" && (
+        <Card
+          className={`${user.subscriptionStatus === "trial" && daysLeftInTrial > 0 ? "bg-blue-50 border-blue-200 dark:bg-blue-950 dark:border-blue-800" : "bg-red-50 border-red-200 dark:bg-red-950 dark:border-red-800"}`}
+        >
+          <CardHeader className="pb-2">
+            <CardTitle className="text-lg flex items-center gap-2">
+              {user.subscriptionStatus === "trial" && daysLeftInTrial > 0 ? (
+                <>
+                  <Zap className="h-5 w-5 text-blue-600" />
+                  14-Day Free Trial
+                </>
+              ) : (
+                <>
+                  <Crown className="h-5 w-5 text-red-600" />
+                  Trial Expired
+                </>
+              )}
+            </CardTitle>
+            <CardDescription>
+              {user.subscriptionStatus === "trial" && daysLeftInTrial > 0
+                ? "Unlimited features during your trial period"
+                : "Upgrade to continue accessing premium features"}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+              <div className="space-y-2 flex-1 w-full">
+                <div className="flex justify-between text-sm">
+                  <span className={getCreditsColor()}>{getCreditsDisplay()}</span>
+                  {user.subscriptionStatus === "trial" && (
+                    <span className="text-muted-foreground">
+                      Day {daysUsed} of {totalTrialDays}
+                    </span>
+                  )}
+                </div>
+                <Progress value={user.subscriptionStatus === "trial" ? trialProgress : 100} className="h-2" />
+              </div>
+              <div className="flex gap-2">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button asChild>
+                        <Link href="/billing">
+                          <CreditCard className="mr-2 h-4 w-4" />
+                          Billing
+                        </Link>
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs">
+                      <div className="space-y-1">
+                        <p className="font-semibold">Premium Benefits:</p>
+                        {premiumBenefits.slice(0, 4).map((benefit, i) => (
+                          <p key={i} className="text-xs">
+                            {benefit}
+                          </p>
+                        ))}
+                        <p className="text-xs text-muted-foreground">...and more!</p>
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+
+                {user.subscriptionStatus !== "trial" || daysLeftInTrial === 0 ? (
+                  <Button
+                    asChild
+                    className="bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700"
+                  >
+                    <Link href="/billing">
+                      <Crown className="mr-2 h-4 w-4" />
+                      Upgrade to Premium
+                    </Link>
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Premium Active Card */}
+      {user.subscriptionPlan === "premium" && (
+        <Card className="bg-gradient-to-r from-purple-50 to-blue-50 border-purple-200 dark:from-purple-950 dark:to-blue-950 dark:border-purple-800">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-lg flex items-center gap-2">
+              <Crown className="h-5 w-5 text-purple-600" />
+              Premium Active
+              <Badge className="bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300">Pro</Badge>
+            </CardTitle>
+            <CardDescription>Enjoy unlimited access to all premium features</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+              <div className="space-y-2 flex-1 w-full">
+                <div className="flex justify-between text-sm">
+                  <span className="text-green-600 font-medium">✅ Premium active – enjoy benefits!</span>
+                  <span className="text-muted-foreground">
+                    Next billing: {new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toLocaleDateString()}
+                  </span>
+                </div>
+                <Progress value={100} className="h-2 bg-purple-100" />
+              </div>
+              <Button asChild variant="outline">
+                <Link href="/billing">
+                  <Settings className="mr-2 h-4 w-4" />
+                  Manage Subscription
+                </Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Subscription Status</CardTitle>
+            <CreditCard className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold flex items-center gap-2">
+              {user.subscriptionPlan === "premium" ? (
+                <>
+                  Premium
+                  <Crown className="h-5 w-5 text-purple-600" />
+                </>
+              ) : (
+                "Free"
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {user.subscriptionStatus === "active"
+                ? "Your subscription is active"
+                : user.subscriptionStatus === "trial"
+                  ? `Trial ends in ${daysLeftInTrial} days`
+                  : "Your subscription is inactive"}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Profile Completion</CardTitle>
+            <User className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{user.avatar ? "80%" : "60%"}</div>
+            <p className="text-xs text-muted-foreground">
+              {user.avatar ? "Complete your billing information" : "Add an avatar and billing information"}
+            </p>
+            <div className="mt-4">
+              <Button variant="outline" size="sm" asChild>
+                <Link href="/dashboard/profile">Complete Profile</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Usage Analytics</CardTitle>
+            <TrendingUp className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {user.subscriptionPlan === "premium" ? "Unlimited" : daysLeftInTrial > 0 ? "Unlimited*" : "Limited"}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {user.subscriptionPlan === "premium"
+                ? "Full access to all features"
+                : daysLeftInTrial > 0
+                  ? "Trial access to all features"
+                  : "Upgrade for unlimited access"}
+            </p>
+            <div className="mt-4">
+              <Button variant="outline" size="sm" asChild>
+                <Link href="/settings">View Analytics</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent Activity</CardTitle>
+            <CardDescription>Your recent actions and updates</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-8">
+              {[
+                { title: "Code Generated", time: "2 hours ago", icon: "💻" },
+                { title: "Architecture Diagram Created", time: "5 hours ago", icon: "📊" },
+                { title: "API Integration Tested", time: "1 day ago", icon: "🔗" },
+                { title: "Profile Updated", time: "2 days ago", icon: "👤" },
+              ].map((activity, i) => (
+                <div key={i} className="flex items-center">
+                  <div className="flex items-center justify-center mr-4">
+                    <div className="rounded-full p-2 bg-primary/10">
+                      <span className="text-sm">{activity.icon}</span>
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">{activity.title}</p>
+                    <p className="text-xs text-muted-foreground">{activity.time}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Quick Actions</CardTitle>
+            <CardDescription>Common tasks and actions</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-2">
+              <Button variant="outline" className="justify-start bg-transparent" asChild>
+                <Link href="/ai-assist">
+                  <Zap className="mr-2 h-4 w-4" />
+                  AI Assistant
+                </Link>
+              </Button>
+              <Button variant="outline" className="justify-start bg-transparent" asChild>
+                <Link href="/projects">
+                  <Shield className="mr-2 h-4 w-4" />
+                  My Projects
+                </Link>
+              </Button>
+              <Button variant="outline" className="justify-start bg-transparent" asChild>
+                <Link href="/dashboard/profile">
+                  <User className="mr-2 h-4 w-4" />
+                  Edit Profile
+                </Link>
+              </Button>
+              <Button variant="outline" className="justify-start bg-transparent" asChild>
+                <Link href="/dashboard/settings">
+                  <Settings className="mr-2 h-4 w-4" />
+                  Account Settings
+                </Link>
+              </Button>
+              <Button variant="outline" className="justify-start bg-transparent" asChild>
+                <Link href="/billing">
+                  <CreditCard className="mr-2 h-4 w-4" />
+                  Manage Subscription
+                </Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,13 +16,15 @@ export default function HomePage() {
     }
   }, [isLoading, isAuthenticated, router])
 
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      router.push("/dashboard")
+    }
+  }, [isLoading, isAuthenticated, router])
+
   if (isLoading || !isAuthenticated) {
     return null // Will redirect to login
   }
 
-  return (
-    <AppLayout>
-      <Dashboard />
-    </AppLayout>
-  )
+  return null // Or a loading spinner, while redirecting to /dashboard
 }

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,3 @@
+
+> codefusion-app@0.1.0 dev /app
+> next dev


### PR DESCRIPTION
- I replaced the existing billing page with a new one that includes a 14-day free trial, plan comparison, and a payment dialog.
- I created a new dashboard page at `/dashboard` with an updated UI to reflect the trial status and premium benefits.
- I updated the root page to redirect authenticated users to the new dashboard.